### PR TITLE
Lazy mailer service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "scripts": {
         "code-analysis/drupal-check": [
-            "drupal-check --deprecations --analysis --exclude-dir=vendor *.* src"
+            "drupal-check --deprecations --analysis --exclude-dir=vendor,*/src/ProxyClass/* *.* src -vvv"
         ],
         "code-analysis": [
             "@code-analysis/drupal-check"

--- a/os2forms_webform_submission_log.services.yml
+++ b/os2forms_webform_submission_log.services.yml
@@ -6,10 +6,10 @@ services:
       - { name: logger }
 
   Drupal\os2forms_webform_submission_log\WebformSubmissionLogMailer:
+    lazy: true
     arguments:
       - '@config.factory'
       - '@plugin.manager.mail'
       - '@language_manager'
-      - '@url_generator'
 
   Drupal\os2forms_webform_submission_log\Helper\WebformHelper:

--- a/src/ProxyClass/WebformSubmissionLogMailer.php
+++ b/src/ProxyClass/WebformSubmissionLogMailer.php
@@ -1,0 +1,88 @@
+<?php
+// phpcs:ignoreFile
+
+/**
+ * This file was generated via php core/scripts/generate-proxy-class.php 'Drupal\os2forms_webform_submission_log\WebformSubmissionLogMailer' "modules/contrib/os2forms_webform_submission_log/src".
+ */
+
+namespace Drupal\os2forms_webform_submission_log\ProxyClass {
+
+    /**
+     * Provides a proxy class for \Drupal\os2forms_webform_submission_log\WebformSubmissionLogMailer.
+     *
+     * @see \Drupal\Component\ProxyBuilder
+     */
+    class WebformSubmissionLogMailer implements \Drupal\os2forms_webform_submission_log\WebformSubmissionLogMailerInterface
+    {
+
+        use \Drupal\Core\DependencyInjection\DependencySerializationTrait;
+
+        /**
+         * The id of the original proxied service.
+         *
+         * @var string
+         */
+        protected $drupalProxyOriginalServiceId;
+
+        /**
+         * The real proxied service, after it was lazy loaded.
+         *
+         * @var \Drupal\os2forms_webform_submission_log\WebformSubmissionLogMailer
+         */
+        protected $service;
+
+        /**
+         * The service container.
+         *
+         * @var \Symfony\Component\DependencyInjection\ContainerInterface
+         */
+        protected $container;
+
+        /**
+         * Constructs a ProxyClass Drupal proxy object.
+         *
+         * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+         *   The container.
+         * @param string $drupal_proxy_original_service_id
+         *   The service ID of the original service.
+         */
+        public function __construct(\Symfony\Component\DependencyInjection\ContainerInterface $container, $drupal_proxy_original_service_id)
+        {
+            $this->container = $container;
+            $this->drupalProxyOriginalServiceId = $drupal_proxy_original_service_id;
+        }
+
+        /**
+         * Lazy loads the real service from the container.
+         *
+         * @return object
+         *   Returns the constructed real service.
+         */
+        protected function lazyLoadItself()
+        {
+            if (!isset($this->service)) {
+                $this->service = $this->container->get($this->drupalProxyOriginalServiceId);
+            }
+
+            return $this->service;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function sendMails(\Drupal\webform\WebformSubmissionInterface $webformSubmission, array $context): void
+        {
+            $this->lazyLoadItself()->sendMails($webformSubmission, $context);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function setLoggerFactory(\Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory)
+        {
+            return $this->lazyLoadItself()->setLoggerFactory($logger_factory);
+        }
+
+    }
+
+}

--- a/src/WebformSubmissionLogLogger.php
+++ b/src/WebformSubmissionLogLogger.php
@@ -16,12 +16,12 @@ final class WebformSubmissionLogLogger implements LoggerInterface {
   /**
    * The os2forms webform submission log mailer service.
    */
-  protected WebformSubmissionLogMailer $submissionLogMailer;
+  protected WebformSubmissionLogMailerInterface $submissionLogMailer;
 
   /**
    * Logger constructor.
    */
-  public function __construct(WebformSubmissionLogMailer $submissionLogMailer) {
+  public function __construct(WebformSubmissionLogMailerInterface $submissionLogMailer) {
     $this->submissionLogMailer = $submissionLogMailer;
   }
 

--- a/src/WebformSubmissionLogMailerInterface.php
+++ b/src/WebformSubmissionLogMailerInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\os2forms_webform_submission_log;
+
+use Drupal\webform\WebformSubmissionInterface;
+
+/**
+ * SubmisionlogMailer service class.
+ */
+interface WebformSubmissionLogMailerInterface {
+
+  /**
+   * Send "failed job" mail to recipients related to webform.
+   *
+   * @param \Drupal\webform\WebformSubmissionInterface $webformSubmission
+   *   The webform submission that failed.
+   * @param array $context
+   *   The logging context.
+   *
+   * @phpstan-param array<string, mixed> $context
+   */
+  public function sendMails(WebformSubmissionInterface $webformSubmission, array $context): void;
+
+}


### PR DESCRIPTION
Makes the mailer service lazy to prevent the error

```
Circular reference detected for service "plugin.manager.mail", path: "webform.email_provider -> plugin.manager.mail -> logger.factory -> Drupal\os2forms_webform_submission_log\WebformSubmissionLogLogger -> Drupal\os2forms_webform_submission_log\Webf
  ormSubmissionLogMailer".
```

where running `drupal_flush_all_caches()`.
